### PR TITLE
Fix config-print to take colorsXX into account

### DIFF
--- a/config-print
+++ b/config-print
@@ -3,13 +3,15 @@
 use v5.20;
 use common::sense;
 
-our @resources = qw(
-    background foreground cursor
-    mouse_background mouse_foreground
-    highlight border
-    font geometry
-    ),
-    map { "color$_" } 0..15;
+our @resources = (
+      qw(
+          background foreground cursor
+          mouse_background mouse_foreground
+          highlight border
+          font geometry
+      ),
+      map { "color$_" } 0..15
+    );
 
 sub on_start {
     for (@resources) {


### PR DESCRIPTION
The second part of the list (built through map) did not seem to be
merged into `@resources`.

Before: `$ urxvt -pe config-print`
```
background: #fdf6e3
foreground: #657b83
cursor: 
mouse_background: 
mouse_foreground: 
highlight: 
border: #fdf6e3
font: xft:InconsolataForPowerline Nerd Font:size=16
geometry:
```

After: `$ urxvt -pe config-print`
```
background: #fdf6e3
foreground: #657b83
cursor:
mouse_background:
mouse_foreground:
highlight:
border: #fdf6e3
font: xft:InconsolataForPowerline Nerd Font:size=16
geometry:
color0: #073642
color1: #dc322f
color2: #859900
color3: #b58900
color4: #268bd2
color5: #d33682
color6: #2aa198
color7: #eee8d5
color8: #002b36
color9: #cb4b16
color10: #586e75
color11: #657b83
color12: #839496
color13: #6c71c4
color14: #93a1a1
color15: #fdf6e3
```

To be fair, I'm not exactly sure what I'm doing since I'm not used to coding in Perl. Chances are, this is not the cleanest or most idiomatic way to do it.

Feel free to comment if there's anything that should be changed !